### PR TITLE
Added headers for Gcc 6.5+

### DIFF
--- a/include/jps3d/planner/jps_2d_util.h
+++ b/include/jps3d/planner/jps_2d_util.h
@@ -9,6 +9,7 @@
 #include <yagsbpl/yagsbpl_base.h>
 #include <yagsbpl/A_star.h>
 #include <unordered_map>
+#include <iostream>
 
 namespace JPS {
   /**

--- a/include/jps3d/planner/jps_3d_util.h
+++ b/include/jps3d/planner/jps_3d_util.h
@@ -9,6 +9,7 @@
 #include <yagsbpl/yagsbpl_base.h>
 #include <yagsbpl/A_star.h>
 #include <unordered_map>
+#include <iostream>
 
 namespace JPS {
  /**


### PR DESCRIPTION
Added iostream headers, as Gcc 6.5+ won't compile without them - even if verbose is false. Another way could be to use #define VERBOSE and #ifdef VERBOSE, but those headers would still be needed.